### PR TITLE
Fix request headers

### DIFF
--- a/src/Driver/GuzzleSoapClientDriver.php
+++ b/src/Driver/GuzzleSoapClientDriver.php
@@ -6,6 +6,7 @@ class GuzzleSoapClientDriver implements SoapClientDriver
 {
 
 	const DEFAULT_TIMEOUT = 2.5;
+	const HEADER_USER_AGENT = 'PHP';
 
 	/** @var \GuzzleHttp\Client */
 	private $httpClient;
@@ -26,10 +27,10 @@ class GuzzleSoapClientDriver implements SoapClientDriver
 	public function send(string $request, string $location, string $action, int $soapVersion): string
 	{
 		$headers = [
-			'User-Agent: PHP',
-			sprintf('Content-Type: %s; charset=utf-8', $soapVersion === 2 ? 'application/soap+xml' : 'text/xml'),
-			sprintf('SOAPAction: %s', $action),
-			sprintf('Content-Length: %s', strlen($request)),
+			'User-Agent' => self::HEADER_USER_AGENT,
+			'Content-Type' => sprintf('%s; charset=utf-8', $soapVersion === 2 ? 'application/soap+xml' : 'text/xml'),
+			'SOAPAction' => $action,
+			'Content-Length' => strlen($request),
 		];
 
 		$request = new \GuzzleHttp\Psr7\Request('POST', $location, $headers, $request);

--- a/tests/SlevomatEET/Driver/GuzzleSoapClientDriverTest.php
+++ b/tests/SlevomatEET/Driver/GuzzleSoapClientDriverTest.php
@@ -1,0 +1,49 @@
+<?php declare(strict_types = 1);
+
+namespace SlevomatEET\Driver;
+
+class GuzzleSoapClientDriverTest extends \PHPUnit\Framework\TestCase
+{
+
+	public function testSend()
+	{
+		$requestData = 'fooData';
+		$responseData = 'responseData';
+		$location = 'https://pg.eet.cz';
+		$soapAction = 'fooAction';
+
+		$guzzleHttpClient = $this->createMock(\GuzzleHttp\Client::class);
+		$guzzleHttpClient
+			->expects(self::once())
+			->method('send')
+			->with(self::callback(function (\GuzzleHttp\Psr7\Request $request) use ($requestData, $location, $soapAction) {
+				$this->assertEquals([
+					'Host' => [
+						'pg.eet.cz',
+					],
+					'User-Agent' => [
+						GuzzleSoapClientDriver::HEADER_USER_AGENT,
+					],
+					'Content-Type' => [
+						'text/xml; charset=utf-8',
+					],
+					'SOAPAction' => [
+						$soapAction,
+					],
+					'Content-Length' => [
+						strlen($requestData),
+					],
+				], $request->getHeaders());
+				$this->assertEquals($location, (string) $request->getUri());
+
+				return true;
+			}))
+			->willReturn(new \GuzzleHttp\Psr7\Response(200, [], $responseData));
+
+		$guzzleSoapClientDriver = new GuzzleSoapClientDriver($guzzleHttpClient);
+		$response = $guzzleSoapClientDriver->send($requestData, $location, $soapAction, SOAP_1_1);
+
+		$this->assertSame($responseData, $response);
+	}
+
+}


### PR DESCRIPTION
Invalid request headers format:

```
POST /eet/services/EETServiceSOAP/v3 HTTP/1.1
Content-Length: 5136
User-Agent: Hele!
Host: prod.eet.cz
0: User-Agent: PHP
1: Content-Type: text/xml; charset=utf-8
2: SOAPAction: http://fs.mfcr.cz/eet/OdeslaniTrzby
3: Content-Length: 5136
```

see http://docs.guzzlephp.org/en/latest/request-options.html#headers

