### PR TITLE
Added methods for return request/response XML

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -30,17 +30,18 @@ class Client
 
 	public function send(Receipt $receipt): EvidenceResponse
 	{
-		$request = new EvidenceRequest($receipt, $this->configuration, $this->cryptographyService);
+		$soapClient = $this->getSoapClient();
+		$request = new EvidenceRequest($soapClient, $receipt, $this->configuration, $this->cryptographyService);
 
 		try {
-			$response = $this->getSoapClient()->OdeslaniTrzby($request->getRequestData());
+			$response = $soapClient->OdeslaniTrzby($request->getRequestData());
 		} catch (DriverRequestFailedException $e) {
 			throw new FailedRequestException($request, $e);
 		} catch (\SoapFault $e) {
 			throw new FailedRequestException($request, $e);
 		}
 
-		$response = new EvidenceResponse($response, $request);
+		$response = new EvidenceResponse($soapClient, $response, $request);
 		if (!$response->isValid()) {
 			throw new InvalidResponseReceivedException($response);
 		}

--- a/src/EvidenceRequest.php
+++ b/src/EvidenceRequest.php
@@ -7,6 +7,8 @@ use SlevomatEET\Cryptography\CryptographyService;
 class EvidenceRequest
 {
 
+	/** @var SoapClient*/
+	private $soapClient;
 	/** @var \DateTimeImmutable */
 	private $sendDate;
 
@@ -22,8 +24,9 @@ class EvidenceRequest
 	/** @var string */
 	private $bkpCode;
 
-	public function __construct(Receipt $receipt, Configuration $configuration, CryptographyService $cryptographyService)
+	public function __construct(SoapClient $soapClient, Receipt $receipt, Configuration $configuration, CryptographyService $cryptographyService)
 	{
+		$this->soapClient = $soapClient;
 		$this->sendDate = new \DateTimeImmutable();
 		$this->header = [
 			'uuid_zpravy' => $receipt->getUuid()->toString(),
@@ -109,4 +112,8 @@ class EvidenceRequest
 		return $this->bkpCode;
 	}
 
+	public function getXml()
+	{
+		return $this->soapClient->__getLastRequest();
+	}
 }

--- a/src/EvidenceResponse.php
+++ b/src/EvidenceResponse.php
@@ -5,6 +5,9 @@ namespace SlevomatEET;
 class EvidenceResponse
 {
 
+	/** @var SoapClient */
+	private $soapClient;
+
 	/** @var \stdClass */
 	private $rawData;
 
@@ -26,8 +29,9 @@ class EvidenceResponse
 	/** @var \SlevomatEET\EvidenceRequest */
 	private $evidenceRequest;
 
-	public function __construct(\stdClass $rawData, EvidenceRequest $evidenceRequest)
+	public function __construct(SoapClient $soapClient, \stdClass $rawData, EvidenceRequest $evidenceRequest)
 	{
+		$this->soapClient = $soapClient;
 		$this->rawData = $rawData;
 		$this->uuid = $rawData->Hlavicka->uuid_zpravy ?? null;
 		if (isset($rawData->Potvrzeni)) {
@@ -89,4 +93,8 @@ class EvidenceResponse
 		return $this->evidenceRequest;
 	}
 
+	public function getXml()
+	{
+		return $this->soapClient->__getLastResponse();
+	}
 }

--- a/tests/SlevomatEET/EvidenceRequestTest.php
+++ b/tests/SlevomatEET/EvidenceRequestTest.php
@@ -13,11 +13,14 @@ class EvidenceRequestTest extends \PHPUnit\Framework\TestCase
 	/** @var \SlevomatEET\Configuration */
 	private $configuration;
 
+	/** @var \PHPUnit_Framework_MockObject_MockObject|\SlevomatEET\SoapClient */
+	private $soapClient;
+
 	public function setUp()
 	{
 		$this->crypto = $this->createMock(CryptographyService::class);
-
 		$this->configuration = new Configuration('CZ00000019', '273', '/5546/RO24', new EvidenceEnvironment(EvidenceEnvironment::PLAYGROUND), true);
+		$this->soapClient = $this->createMock(SoapClient::class);
 	}
 
 	public function testRequestFormatting()
@@ -36,7 +39,10 @@ class EvidenceRequestTest extends \PHPUnit\Framework\TestCase
 		$this->crypto->method('getBkpCode')
 			->willReturn('456');
 
-		$request = new EvidenceRequest($receipt, $this->configuration, $this->crypto);
+		$this->soapClient->method('__getLastRequest')
+			->willReturn('<?xml');
+
+		$request = new EvidenceRequest($this->soapClient, $receipt, $this->configuration, $this->crypto);
 
 		$requestData = $request->getRequestData();
 
@@ -85,6 +91,7 @@ class EvidenceRequestTest extends \PHPUnit\Framework\TestCase
 
 		$this->assertSame('123', $request->getPkpCode());
 		$this->assertSame('456', $request->getBkpCode());
+		$this->assertSame('<?xml', $request->getXml());
 
 		$this->assertInstanceOf(\DateTimeImmutable::class, $request->getSendDate());
 


### PR DESCRIPTION
If is required XML from request/response, then it's impossible to obtain.