### PR TITLE
Improve PHPUnit fixture methods

### DIFF
--- a/tests/SlevomatEET/ClientTest.php
+++ b/tests/SlevomatEET/ClientTest.php
@@ -15,7 +15,7 @@ class ClientTest extends TestCase
 	/** @var Configuration */
 	private $configuration;
 
-	public function setUp(): void
+	protected function setUp(): void
 	{
 		$this->configuration = new Configuration('CZ00000019', '273', '/5546/RO24', EvidenceEnvironment::get(EvidenceEnvironment::PLAYGROUND), false);
 	}

--- a/tests/SlevomatEET/EvidenceRequestTest.php
+++ b/tests/SlevomatEET/EvidenceRequestTest.php
@@ -13,7 +13,7 @@ class EvidenceRequestTest extends TestCase
 	/** @var Configuration */
 	private $configuration;
 
-	public function setUp(): void
+	protected function setUp(): void
 	{
 		$this->configuration = new Configuration('CZ00000019', '273', '/5546/RO24', EvidenceEnvironment::get(EvidenceEnvironment::PLAYGROUND), true);
 	}


### PR DESCRIPTION
# Changed log
- According to the [PHPUnit fixture reference](https://phpunit.readthedocs.io/en/8.5/fixtures.html?highlight=fixtures), the `setUp` method is `protected`.